### PR TITLE
Bumped e4 version to point on renamed package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/sirupsen/logrus v1.2.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3
-	github.com/teserakt-io/e4go v1.0.1-0.20191212110050-639cf4d1ee4b
+	github.com/teserakt-io/e4go v1.0.1-0.20191218100317-7b4c9b308a2e
 	github.com/teserakt-io/serverlib v0.0.0-20190912131345-29a7b76ad87c
 	go.opencensus.io v0.22.1
 	google.golang.org/genproto v0.0.0-20190911173649-1774047e7e51

--- a/go.sum
+++ b/go.sum
@@ -220,8 +220,8 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/teserakt-io/e4go v0.0.0-20190912121911-ef9603112859 h1:fdzuYS+7zF82oNIMg255K5dOfAUzXAS6h2Ew/ZlrU/w=
 github.com/teserakt-io/e4go v0.0.0-20190912121911-ef9603112859/go.mod h1:eG2YPACiGMpr9XNwj5aIg9LZqQknj7sVtLcymqW0A7I=
-github.com/teserakt-io/e4go v1.0.1-0.20191212110050-639cf4d1ee4b h1:zHsEB8kuwO+kkF3moSzRwpVpf2z8ftGw27rS2zVumMU=
-github.com/teserakt-io/e4go v1.0.1-0.20191212110050-639cf4d1ee4b/go.mod h1:LAUemYwJ/Ersq9WvPUVILKdzPbAzKONV6j3PvN5JqxM=
+github.com/teserakt-io/e4go v1.0.1-0.20191218100317-7b4c9b308a2e h1:n+LnE6HxuUO1K0RYe2cXYgafS7i9tBVO4aN02BO2zOw=
+github.com/teserakt-io/e4go v1.0.1-0.20191218100317-7b4c9b308a2e/go.mod h1:LAUemYwJ/Ersq9WvPUVILKdzPbAzKONV6j3PvN5JqxM=
 github.com/teserakt-io/serverlib v0.0.0-20190912131345-29a7b76ad87c h1:4VZwgi8DLRJIAqFtiaIDbl87NWyjMf3aBvZ4dpF2VKA=
 github.com/teserakt-io/serverlib v0.0.0-20190912131345-29a7b76ad87c/go.mod h1:Royi7lAJYr1NUXhN2qmqaKeHDMCxfw8XhFm9tyYFxbU=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
Related e4go issue: https://github.com/teserakt-io/e4go/pull/17