### PR TITLE
Added back application field in log removed by last merge

### DIFF
--- a/cmd/c2/c2.go
+++ b/cmd/c2/c2.go
@@ -50,6 +50,8 @@ func main() {
 		defer logFile.Close()
 	}
 
+	logger = logger.WithField("application", "c2")
+
 	defer func() {
 		if r := recover(); r != nil {
 			logger.WithError(fmt.Errorf("%v", r)).Error("c2 panic")


### PR DESCRIPTION
Kibana fails to display c2 logs and dashboard as from last merge application identifier where removed by mistake.